### PR TITLE
Fix libc version conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ documentation = "https://docs.rs/pfm"
 [dependencies]
 pfm-sys = {path = "./pfm-sys", version = "0.0.13"}
 perf-event-open-sys = "1.0.1"
-libc = "0.2.94"
+libc = "0.2"


### PR DESCRIPTION
I'm having a libc version conflict error when enabling "pfm" on mmtk v0.7.0:

* `bindgen` requires `libc v0.2.91`
* `pfm` requires `libc v0.2.94`

```
    Updating crates.io index
error: failed to select a version for `libc`.
    ... required by package `pfm v0.0.9`
    ... which satisfies dependency `pfm = "^0.0.9"` of package `mmtk v0.7.0 (/home/wenyuz/MMTk-Dev/mmtk-core)`
    ... which satisfies git dependency `mmtk` of package `mmtk_openjdk v0.7.0 (/home/wenyuz/MMTk-Dev/mmtk-openjdk/mmtk)`
versions that meet the requirements `^0.2.94` are: 0.2.104, 0.2.103, 0.2.102, 0.2.101, 0.2.100, 0.2.99, 0.2.98, 0.2.97, 0.2.96, 0.2.95, 0.2.94

all possible versions conflict with previously selected packages.

  previously selected package `libc v0.2.91`
    ... which satisfies dependency `libc = "=0.2.91"` of package `atty v0.2.14`
    ... which satisfies dependency `atty = "=0.2.14"` of package `env_logger v0.8.3`
    ... which satisfies dependency `env_logger = "=0.8.3"` of package `bindgen v0.58.1`
    ... which satisfies dependency `bindgen = "^0.58.1"` of package `pfm-sys v0.0.13`
    ... which satisfies dependency `pfm-sys = "^0.0.13"` of package `pfm v0.0.9`
    ... which satisfies dependency `pfm = "^0.0.9"` of package `mmtk v0.7.0 (/home/wenyuz/MMTk-Dev/mmtk-core)`
    ... which satisfies git dependency `mmtk` of package `mmtk_openjdk v0.7.0 (/home/wenyuz/MMTk-Dev/mmtk-openjdk/mmtk)`

failed to select a version for `libc` which could resolve this conflict
```

This change removes the fixed libc version requirement for pfm.